### PR TITLE
added renovate support

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":enableVulnerabilityAlertsWithLabel('security')",
+    ":preserveSemverRanges",
+    ":rebaseStalePrs",
+    "group:recommended"
+  ],
+  "labels": ["renovate"],
+  "separateMinorPatch": true,
+  "stopUpdatingLabel": "renovate/stop_updating",
+
+  "packageRules": [
+    {
+      "description": "Automerge only for Patches",
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
+      "description": "No Auto-PRs for Major-Updates",
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Support for Dockerfile",
+      "matchManagers": ["dockerfile"],
+      "groupName": "Docker image updates"
+    },
+    {
+      "description": "Support for GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions updates"
+    },
+    {
+      "description": "Security-Updates for Docker und GitHub Actions auto merge",
+      "matchManagers": ["dockerfile", "github-actions"],
+      "matchUpdateTypes": ["security"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update GitHub Actions usage in README",
+      "fileMatch": ["^README\\.md$"],
+      "matchStrings": [
+        "uses:\\s*dombyte/docker-deploy@(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "dombyte/docker-deploy",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🚀 Deploy via Docker Compose over SSH
-        uses: dombyte/docker-deploy@v1
+        uses: dombyte/docker-deploy@v0.1.0
         with:
           ssh_host: ${{ secrets.SSH_HOST }}
           ssh_user: ${{ secrets.SSH_USER }}


### PR DESCRIPTION
This pull request introduces a new Renovate configuration file to automate dependency updates and updates the GitHub Actions usage in the `README.md` file to specify a more precise version of the `dombyte/docker-deploy` action.

### Renovate configuration setup:

* Added a new `.github/renovate.json` file to configure Renovate for dependency management. This includes enabling features like dependency dashboards, vulnerability alerts with labels, and patch-level automerge for Dockerfiles. It also introduces custom rules for grouping updates and managing security updates for Docker and GitHub Actions.

